### PR TITLE
Singlet symmetry-reduced UCCSD

### DIFF
--- a/tangelo/algorithms/variational/tests/test_vqe_solver.py
+++ b/tangelo/algorithms/variational/tests/test_vqe_solver.py
@@ -252,6 +252,9 @@ class VQESolverTest(unittest.TestCase):
 
         energy = vqe_solver.simulate()
         self.assertAlmostEqual(energy, -1.97783, delta=1e-4)
+        # Test that the number of variational parameters is less than the total possible number
+        self.assertEqual(vqe_solver.ansatz.n_var_params, 10)
+        self.assertEqual(vqe_solver.ansatz.n_full_var_params, 14)
 
     def test_simulate_qmf_h4(self):
         """Run VQE on H4 molecule, with QMF ansatz, JW qubit mapping, initial
@@ -332,7 +335,7 @@ class VQESolverTest(unittest.TestCase):
         energy = vqe_solver.simulate()
         self.assertAlmostEqual(energy, -1.6394, delta=1e-3)
 
-    def test_simulate_h4_open(self):
+    def test_simulate_h4_uhf_a1_frozen(self):
         """Run VQE on H4 molecule, with UCCSD ansatz, scbk qubit mapping, initial parameters, exact simulator """
         vqe_options = {"molecule": mol_H4_sto3g_uhf_a1_frozen, "ansatz": BuiltInAnsatze.UCCSD, "qubit_mapping": "scbk",
                         "initial_var_params": [0.001]*15, "verbose": False, "up_then_down": True}

--- a/tangelo/problem_decomposition/dmet/fragment.py
+++ b/tangelo/problem_decomposition/dmet/fragment.py
@@ -70,6 +70,7 @@ class SecondQuantizedDMETFragment:
 
         self.n_mos = len(self.mean_field.mo_energy[0]) if self.uhf else len(self.mean_field.mo_energy)
         self.mo_occ = self.mean_field.mo_occ
+        self.symmetry = False
 
         list_of_active_frozen = convert_frozen_orbitals(self, self.frozen_orbitals)
         self.active_occupied = list_of_active_frozen[0]

--- a/tangelo/toolboxes/ansatz_generator/_unitary_cc.py
+++ b/tangelo/toolboxes/ansatz_generator/_unitary_cc.py
@@ -1,0 +1,164 @@
+# Copyright 2023 Good Chemistry Company.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Module to create and manipulate unitary coupled cluster operators for
+   open shell systems. This requires the number of alpha and beta electrons
+   to be specified.
+"""
+
+import itertools
+from typing import Dict, Tuple
+
+import numpy
+from openfermion.utils import down_index, up_index
+
+from tangelo.toolboxes.operators import FermionOperator
+
+
+def uccsd_singlet_generator(n_qubits,
+                            n_electrons,
+                            anti_hermitian=True) -> Tuple[Dict[int, Tuple[int]], Dict[Tuple[int], FermionOperator]]:
+    """Create two dictionaries that map the packed amplitudes to the corresponding UCCSD generator.
+
+    This function generates the FermionOperator for each UCCSD generator designed
+        to act on a single reference state consisting of n_qubits spin orbitals
+        and n_electrons electrons, that is a spin singlet operator, meaning it
+        conserves spin.
+
+    Args:
+        n_qubits(int): Number of spin-orbitals used to represent the system,
+            which also corresponds to number of qubits in a non-compact map.
+        n_electrons(int): Number of electrons in the physical system.
+        anti_hermitian(Bool): Flag to generate only normal CCSD operator
+            rather than unitary variant, primarily for testing
+
+    Returns:
+        Tuple[Dict, Dict]: (Mapping from packed_amplitude integer to generator, Mapping from generator to FermionOperator)
+    """
+    if n_qubits % 2 != 0:
+        raise ValueError('The total number of spin-orbitals should be even.')
+
+    n_spatial_orbitals = n_qubits // 2
+    n_occupied = int(numpy.ceil(n_electrons / 2))
+    n_virtual = n_spatial_orbitals - n_occupied
+
+    # Get amplitude indices
+    n_single_amplitudes = n_occupied * n_virtual
+
+    # Parameter dict
+    param_dict = dict()
+
+    # Operator dict
+    operator_dict = dict()
+
+    # Generate excitations
+    spin_index_functions = [up_index, down_index]
+    # Generate all spin-conserving single and double excitations derived
+    # from one spatial occupied-virtual pair
+    for i, (p, q) in enumerate(
+            itertools.product(range(n_virtual), range(n_occupied))):
+
+        # Get indices of spatial orbitals
+        virtual_spatial = n_occupied + p
+        occupied_spatial = q
+
+        for spin in range(2):
+            # Get the functions which map a spatial orbital index to a
+            # spin orbital index
+            this_index = spin_index_functions[spin]
+            other_index = spin_index_functions[1 - spin]
+
+            # Get indices of spin orbitals
+            virtual_this = this_index(virtual_spatial)
+            virtual_other = other_index(virtual_spatial)
+            occupied_this = this_index(occupied_spatial)
+            occupied_other = other_index(occupied_spatial)
+
+            # Generate single excitations
+            generator = FermionOperator(
+                ((virtual_this, 1), (occupied_this, 0)), 1)
+            if anti_hermitian:
+                generator += FermionOperator(
+                    ((occupied_this, 1), (virtual_this, 0)), -1)
+            excitation = (virtual_spatial, occupied_spatial)
+            param_dict[i] = excitation
+            operator_dict[excitation] = operator_dict.get(excitation, FermionOperator()) + generator
+
+            # Generate double excitation
+            generator = FermionOperator(
+                ((virtual_this, 1), (occupied_this, 0), (virtual_other, 1),
+                 (occupied_other, 0)), 1)
+            if anti_hermitian:
+                generator += FermionOperator(
+                    ((occupied_other, 1), (virtual_other, 0),
+                     (occupied_this, 1), (virtual_this, 0)), -1)
+            excitation = (virtual_spatial, occupied_spatial, virtual_spatial, occupied_spatial)
+            param_dict[i + n_single_amplitudes] = excitation
+            operator_dict[excitation] = operator_dict.get(excitation, FermionOperator()) + generator
+
+    # Generate all spin-conserving double excitations derived
+    # from two spatial occupied-virtual pairs
+    for i, ((p, q), (r, s)) in enumerate(
+            itertools.combinations(
+                itertools.product(range(n_virtual), range(n_occupied)), 2)):
+
+        # Get indices of spatial orbitals
+        virtual_spatial_1 = n_occupied + p
+        occupied_spatial_1 = q
+        virtual_spatial_2 = n_occupied + r
+        occupied_spatial_2 = s
+
+        # Generate double excitations
+        for (spin_a, spin_b) in itertools.product(range(2), repeat=2):
+            # Get the functions which map a spatial orbital index to a
+            # spin orbital index
+            index_a = spin_index_functions[spin_a]
+            index_b = spin_index_functions[spin_b]
+
+            # Get indices of spin orbitals
+            virtual_1_a = index_a(virtual_spatial_1)
+            occupied_1_a = index_a(occupied_spatial_1)
+            virtual_2_b = index_b(virtual_spatial_2)
+            occupied_2_b = index_b(occupied_spatial_2)
+
+            if virtual_1_a == virtual_2_b:
+                continue
+            if occupied_1_a == occupied_2_b:
+                continue
+            else:
+
+                generator = FermionOperator(
+                    ((virtual_1_a, 1), (occupied_1_a, 0), (virtual_2_b, 1),
+                     (occupied_2_b, 0)), 1)
+                if anti_hermitian:
+                    generator += FermionOperator(
+                        ((occupied_2_b, 1), (virtual_2_b, 0), (occupied_1_a, 1),
+                         (virtual_1_a, 0)), -1)
+                excitation = (virtual_spatial_1, occupied_spatial_1, virtual_spatial_2, occupied_spatial_2)
+                param_dict[i + 2*n_single_amplitudes] = excitation
+                operator_dict[excitation] = operator_dict.get(excitation, FermionOperator()) + generator
+
+    return param_dict, operator_dict

--- a/tangelo/toolboxes/ansatz_generator/uccsd.py
+++ b/tangelo/toolboxes/ansatz_generator/uccsd.py
@@ -252,9 +252,14 @@ class UCCSD(Ansatz):
 
         # If symmetry is present, only keep parameters that have the original irreduciple representation.
         if self.molecule.symmetry:
-            params2keep = []
+
+            # Obtain the symmetry ids for each molecular orbital
             mo_ids = [self.molecule.mo_symm_ids[i] for i in self.molecule.active_occupied+self.molecule.active_virtual]
+
+            # Go through each excitation operator and determine the result irrep.
+            params2keep = []
             for key, value in self.param_dict.items():
+                # Generate the reference configuration. The irrep is always 0 for a singlet
                 ref_occ = [list(range(self.n_occupied)), list(range(self.n_occupied))]
                 if len(value) == 2:
                     ref_occ[0].remove(value[1])
@@ -263,6 +268,7 @@ class UCCSD(Ansatz):
                     for s in range(2):
                         for occ in ref_occ[s]:
                             irrep ^= mo_ids[occ]
+                    # If the irrep stays 0, that parameter can contribute
                     if irrep == 0:
                         params2keep += [key]
                 else:
@@ -274,6 +280,7 @@ class UCCSD(Ansatz):
                     for s in range(2):
                         for occ in ref_occ[s]:
                             irrep ^= mo_ids[occ]
+                    # If the irrep stays 0, that parameter can contribute
                     if irrep == 0:
                         params2keep += [key]
             self.params2keep = params2keep


### PR DESCRIPTION
Utilizes symmetry to reduce the number of parameters for singlet UCCSD. Also generates the variables

param_dict. Maps the parameter indice to the corresponding spatial orbital excitation
param_dict[0] = (2, 0) means that parameter 1 is utilized for the single excitation (2^0 - 0^2) + (3 ^1 - 1^ 3) for example.

operator_dict maps the excitation to the FermionOperator.

params2keep is the list of parameters from the full packed_amplitudes that are kept in the optimization process. This could be modified by the user if some excitations are known to be small.
