### PR TITLE
Interface to quantum resource estimation (QRE) tools

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -82,6 +82,12 @@ jobs:
         python -m pip install openbabel-wheel
       if: always()
 
+    - name: Install dependencies for QRE
+      run: |
+        pip install openfermionpyscf
+        pip install benchq
+      if: always()
+
     - name: tangelo tests
       run: |
         cd tangelo

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -82,12 +82,6 @@ jobs:
         python -m pip install openbabel-wheel
       if: always()
 
-    - name: Install dependencies for QRE
-      run: |
-        pip install openfermionpyscf
-        pip install benchq
-      if: always()
-
     - name: tangelo tests
       run: |
         cd tangelo

--- a/tangelo/toolboxes/circuits/qre.py
+++ b/tangelo/toolboxes/circuits/qre.py
@@ -103,7 +103,7 @@ def qre_pyliqtr(sec_mol, error=0.0016, **kwargs):
     # Get phase estimation QRE.
     phase_est = QubitizedPhaseEstimation(
         # https://github.com/isi-usc-edu/pyLIQTR/blob/main/src/pyLIQTR/BlockEncodings/DoubleFactorized.py
-        getEncoding(VALID_ENCODINGS.DoubleFactorized, **kwargs),
+        getEncoding(VALID_ENCODINGS.DoubleFactorized, energy_error=error, **kwargs),
         instance=mol_instance
     )
 

--- a/tangelo/toolboxes/circuits/qre.py
+++ b/tangelo/toolboxes/circuits/qre.py
@@ -1,0 +1,89 @@
+# Copyright SandboxAQ 2021-2024.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module provides the QRE class for handling quantum resource estimation
+(QRE) in quantum chemistry problems. The QRE class is initialized with a
+`sec_mol` object, which is used to obtain one-body and two-body integrals,
+relevant for QRE.
+"""
+
+
+class QRE:
+    """A class for estimating quantum resources for a given molecule.
+
+    Attributes:
+        sec_mol (SecondQuantizedMolecule): Self-explanatory.
+        one_body_int (array): The one-body integrals of the molecule.
+        two_body_int (array): The two-body integrals of the molecule.
+
+    Methods:
+        benchq(threshold, **kwargs):
+            Calculates the Toffoli and qubit cost using the benchq library.
+        pennylane(**kwargs):
+            Calculates the double factorization resource cost using the
+            Pennylane library.
+    """
+
+    def __init__(self, sec_mol):
+        """Initialize the QRE object with a given quantum molecule.
+
+        Args:
+            sec_mol (SecondQuantizedMolecule): Self-explanatory.
+        """
+        self.sec_mol = sec_mol
+        _, self.one_body_int, self.two_body_int = self.sec_mol.get_integrals(fold_frozen=True)
+
+    def benchq(self, threshold, **kwargs):
+        """Calculate the Toffoli and qubit cost using the benchq library. For
+        more details, see the benchq documentation:
+        https://github.com/zapatacomputing/benchq/blob/main/src/benchq/problem_embeddings/qpe.py#L128
+
+        Dependencies:
+            - benchq
+            - openfermionpycf
+
+        Args:
+            threshold (float): The threshold parameter for the double
+                factorization algorithm.
+            **kwargs: Additional parameters to pass to the `benchq` function.
+
+        Returns:
+            (int, int): A tuple containing the Toffoli and qubit cost.
+        """
+
+        from benchq.problem_embeddings.qpe import get_double_factorized_qpe_toffoli_and_qubit_cost
+
+        return get_double_factorized_qpe_toffoli_and_qubit_cost(self.one_body_int,
+            self.two_body_int, threshold, **kwargs)
+
+    def pennylane(self, **kwargs):
+        """Calculate the double factorization resource cost using the Pennylane
+        library. For more details, see the Pennylane documentation:
+        https://docs.pennylane.ai/en/stable/code/api/pennylane.resource.DoubleFactorization.html
+
+        Dependency:
+            - pennylane
+
+        Args:
+            **kwargs: Additional parameters to pass to the
+                `DoubleFactorization` constructor.
+
+        Returns:
+            DoubleFactorization: An instance of the Pennylane
+                DoubleFactorization resource.
+        """
+
+        from pennylane.resource import DoubleFactorization
+
+        return DoubleFactorization(self.one_body_int, self.two_body_int, **kwargs)

--- a/tangelo/toolboxes/circuits/qre.py
+++ b/tangelo/toolboxes/circuits/qre.py
@@ -18,8 +18,6 @@ SecondQuantizedMolecule object, which is used to obtain one-body and two-body
 integrals, relevant for QRE.
 """
 
-import numpy as np
-
 
 def qre_benchq(sec_mol, threshold, **kwargs):
     """Calculate the Toffoli and qubit cost using the benchq library. For
@@ -31,6 +29,8 @@ def qre_benchq(sec_mol, threshold, **kwargs):
         - openfermionpycf
 
     Args:
+        sec_mol (SecondQuantizedMolecule): Molecular system for evaluating the
+            quantum resources.
         threshold (float): The threshold parameter for the double
             factorization algorithm.
         **kwargs: Additional parameters to pass to the `benchq` function.
@@ -55,6 +55,8 @@ def qre_pennylane(sec_mol, **kwargs):
         - pennylane
 
     Args:
+        sec_mol (SecondQuantizedMolecule): Molecular system for evaluating the
+            quantum resources.
         **kwargs: Additional parameters to pass to the
             `DoubleFactorization` constructor.
 
@@ -81,6 +83,8 @@ def qre_pyliqtr(sec_mol, error=0.0016, **kwargs):
         - openfermionpyscf
 
     Args:
+        sec_mol (SecondQuantizedMolecule): Molecular system for evaluating the
+            quantum resources.
         **kwargs: Additional parameters to pass to the
             `DoubleFactorization` constructor.
 

--- a/tangelo/toolboxes/circuits/tests/test_qre.py
+++ b/tangelo/toolboxes/circuits/tests/test_qre.py
@@ -17,6 +17,7 @@ import unittest
 from tangelo.molecule_library import mol_H10_321g
 from tangelo.toolboxes.circuits.qre import qre_benchq, qre_pennylane
 
+
 class QRETest(unittest.TestCase):
 
     def test_qre_benchq(self):

--- a/tangelo/toolboxes/circuits/tests/test_qre.py
+++ b/tangelo/toolboxes/circuits/tests/test_qre.py
@@ -1,0 +1,43 @@
+# Copyright SandboxAQ 2021-2024.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from tangelo.molecule_library import mol_H10_321g
+from tangelo.toolboxes.circuits.qre import qre_benchq, qre_pennylane
+
+class QRETest(unittest.TestCase):
+
+    def test_qre_benchq(self):
+        """Test the QRE output type for the benchq interface."""
+
+        n_toffolis, n_qubits = qre_benchq(mol_H10_321g, 1e-6)
+
+        self.assertIsInstance(n_toffolis, int)
+        self.assertIsInstance(n_qubits, int)
+
+        # As done in tests/benchq/problem_embeddings/test_qpe.py in benchq repo.
+        self.assertGreater(n_qubits, mol_H10_321g.n_active_sos)
+
+    def test_qre_pennylane(self):
+        """Test the QRE output type for the pennylane interface."""
+
+        output = qre_pennylane(mol_H10_321g)
+
+        self.assertIsInstance(output.gates, int)
+        self.assertIsInstance(output.qubits, int)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tangelo/toolboxes/circuits/tests/test_qre.py
+++ b/tangelo/toolboxes/circuits/tests/test_qre.py
@@ -15,7 +15,7 @@
 import unittest
 
 from tangelo.molecule_library import mol_H10_321g
-from tangelo.toolboxes.circuits.qre import qre_benchq, qre_pennylane
+from tangelo.toolboxes.circuits.qre import qre_benchq, qre_pennylane, qre_pyliqtr
 
 
 class QRETest(unittest.TestCase):
@@ -39,6 +39,17 @@ class QRETest(unittest.TestCase):
 
         self.assertIsInstance(output.gates, int)
         self.assertIsInstance(output.qubits, int)
+
+    @unittest.skip("Installing pyLIQTR requires and old cirq version that breaks linq tests.")
+    def test_qre_pyliqtr(self):
+        """Test the QRE output type for the pyLIQTR interface."""
+
+        output = qre_pyliqtr(mol_H10_321g)
+
+        self.assertIsInstance(output.get("LogicalQubits"), int)
+        self.assertIsInstance(output.get("T"), int)
+        self.assertIsInstance(output.get("Clifford"), int)
+        self.assertIsInstance(output.get("lambda"), float)
 
 
 if __name__ == "__main__":

--- a/tangelo/toolboxes/circuits/tests/test_qre.py
+++ b/tangelo/toolboxes/circuits/tests/test_qre.py
@@ -20,6 +20,7 @@ from tangelo.toolboxes.circuits.qre import qre_benchq, qre_pennylane
 
 class QRETest(unittest.TestCase):
 
+    @unittest.skip("Installing benchq enforces an old qiskit version that breaks our qiskit interface.")
     def test_qre_benchq(self):
         """Test the QRE output type for the benchq interface."""
 

--- a/tangelo/toolboxes/molecular_computation/molecule.py
+++ b/tangelo/toolboxes/molecular_computation/molecule.py
@@ -340,7 +340,7 @@ class SecondQuantizedMolecule(Molecule):
         if hasattr(self.solver, "assign_mo_coeff_symmetries") and self.symmetry:
             self.solver.assign_mo_coeff_symmetries(self)
 
-    def _get_fermionic_hamiltonian(self, mo_coeff=None):
+    def _get_fermionic_hamiltonian(self, mo_coeff=None, get_mol=False):
         """This method returns the fermionic hamiltonian. It written to take
         into account calls for this function is without argument, and attributes
         are parsed into it.
@@ -360,7 +360,10 @@ class SecondQuantizedMolecule(Molecule):
 
         molecular_hamiltonian = reps.InteractionOperator(core_constant, one_body_coefficients, 1 / 2 * two_body_coefficients)
 
-        return get_fermion_operator(molecular_hamiltonian)
+        if get_mol:
+            return molecular_hamiltonian
+        else:
+            return get_fermion_operator(molecular_hamiltonian)
 
     def freeze_mos(self, frozen_orbitals, inplace=True):
         """This method recomputes frozen orbitals with the provided input."""


### PR DESCRIPTION
Interface to other software quantum resource estimation (QRE) tools. 

As of now, it supports:
 - [Benchq](https://github.com/zapatacomputing/benchq)
 - [Pennylane](https://github.com/PennyLaneAI/pennylane)
 - [PyLIQTR](https://github.com/isi-usc-edu/pyLIQTR.git)

There is no test at the moment for PyLIQTR because it is only working with a specific `cirq` version (`cirq-core==1.3.0.dev20231018023458`), and it is breaking the `tangelo.linq` module.