### PR TITLE
dotnet version updates

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -50,11 +50,11 @@ jobs:
 
     - name: Install Microsoft qsharp/qdk
       run: |
-        wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+        wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
         sudo dpkg -i packages-microsoft-prod.deb
         rm packages-microsoft-prod.deb
         sudo apt-get update; sudo apt-get install -y apt-transport-https && sudo apt-get update
-        sudo apt-get install -y dotnet-sdk-5.0
+        sudo apt-get install -y dotnet-sdk-9.0
         dotnet tool install -g Microsoft.Quantum.IQSharp
         $(which dotnet-iqsharp) install --user
         pip install qsharp


### PR DESCRIPTION
Microsoft Q# and dotnet install fails (hardcoded values for Ubuntu image version and dotnet version, while build uses `ubuntu-latest` and therefore drifts)